### PR TITLE
allow flexible settings in [realms] section

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Boolean if reverse DNS resolution should be used
 
 realms
 ------
-List of kerberos domains
+List of kerberos domains (hash with nested arrays)
 
 - *Default*: undef
 
@@ -97,7 +97,8 @@ List of kerberos domains
 <pre>
 krb5::realms:
   'EXAMPLE.COM':
-    default_domain: 'example.com'
+    default_domain:
+      - 'example.com'
     kdc:
       - 'kdc1.example.com:88'
       - 'kdc2.example.com:88'

--- a/spec/fixtures/krb5.conf.allset
+++ b/spec/fixtures/krb5.conf.allset
@@ -26,16 +26,16 @@ pam = {
 
 [realms]
 ANOTHER.EXAMPLE.COM = {
-  kdc = kdc1.another.example.com:88
   admin_server = kdc1.another.example.com:749
   default_domain = another.example.com
+  kdc = kdc1.another.example.com:88
 }
 EXAMPLE.COM = {
-  kdc = kdc1.example.com:88
-  kdc = kdc2.example.com:88
   admin_server = kdc1.example.com:749
   admin_server = kdc2.example.com:749
   default_domain = example.com
+  kdc = kdc1.example.com:88
+  kdc = kdc2.example.com:88
 }
 
 [domain_realm]

--- a/spec/fixtures/krb5.conf.realms
+++ b/spec/fixtures/krb5.conf.realms
@@ -2,9 +2,9 @@
 
 [realms]
 EXAMPLE.COM = {
-  kdc = kdc1.example.com:88
-  kdc = kdc2.example.com:88
   admin_server = kdc1.example.com:749
   admin_server = kdc2.example.com:749
   default_domain = example.com
+  kdc = kdc1.example.com:88
+  kdc = kdc2.example.com:88
 }

--- a/templates/krb5.conf.erb
+++ b/templates/krb5.conf.erb
@@ -54,31 +54,19 @@ rdns = <%= @rdns %>
 <% if @realms -%>
 
 [realms]
-<% @realms.keys.sort.each do |key| -%>
+<%   @realms.sort.each do |key, hash| -%>
 <%= key %> = {
-<% if @realms[key]['kdc'] -%>
-<% if @realms[key]['kdc'].is_a?(Array) -%>
-<% @realms[key]['kdc'].sort.each do |kdc| -%>
-  kdc = <%= kdc %>
-<% end -%>
-<% else -%>
-  kdc = <%= @realms[key]['kdc'] %>
-<% end -%>
-<% end -%>
-<% if @realms[key]['admin_server'] -%>
-<% if @realms[key]['admin_server'].is_a?(Array) -%>
-<% @realms[key]['admin_server'].sort.each do |as| -%>
-  admin_server = <%= as %>
-<% end -%>
-<% else -%>
-  admin_server = <%= @realms[key]['admin_server'] %>
-<% end -%>
-<% end -%>
-<% if @realms[key]['default_domain'] -%>
-  default_domain = <%= @realms[key]['default_domain'] %>
-<% end -%>
+<%     hash.sort.each do |option, values| -%>
+<%       if values.is_a?(Array) -%>
+<%         values.sort.each do |value| -%>
+  <%= option %> = <%= value %>
+<%       end -%>
+<%       else -%>
+  <%= option %> = <%= values %>
+<%       end -%>
+<%     end -%>
 }
-<% end -%>
+<%   end -%>
 <% end -%>
 <% if @domain_realm -%>
 


### PR DESCRIPTION
This patch allows to use whatever settings in [realms] section. For backward compatibility it also supports strings instead of arrays. Readme example was changed from string to array.

Fixture files were updated because of alphabetical sorting of options. Without sorting enabled, Puppet mix the sequence from time to time.
